### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -179,7 +179,7 @@ jobs:
           npm install
           npm build
       - name: Push to Quay.io
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: quay.io
           name: konveyor/tackle-ui

--- a/.github/workflows/pr-build-container-images.yml
+++ b/.github/workflows/pr-build-container-images.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
       - name: Push to GitHub Packages
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: ghcr.io
           name: ${{ github.repository_owner }}/${{ github.event.repository.name }}/tackle-ui


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore